### PR TITLE
Fixing build errors

### DIFF
--- a/Client/Client.cs
+++ b/Client/Client.cs
@@ -21,23 +21,15 @@
 
 namespace DeltaQueryClient
 {
+    using Microsoft.Identity.Client;
     using System;
     using System.Collections.Generic;
     using System.Collections.Specialized;
-    using System.Diagnostics.CodeAnalysis;
-    using System.Globalization;
-    using System.IO;
     using System.Linq;
     using System.Net;
-    using System.Runtime.Serialization;
-    using System.Runtime.Serialization.Json;
     using System.Text;
-    using System.Web;
-    using System.Web.Script.Serialization;
-    using Microsoft.IdentityModel.Clients.ActiveDirectory;
-    using Microsoft.Identity.Client;
     using System.Threading.Tasks;
-    using System.Security.Claims;
+    using System.Web.Script.Serialization;
 
     /// <summary>
     /// Sample implementation of obtaining changes from graph using Delta Query.

--- a/Client/DeltaQueryClient.csproj
+++ b/Client/DeltaQueryClient.csproj
@@ -52,24 +52,26 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Identity.Client">
-      <HintPath>..\..\..\..\CxCache\Microsoft.Identity.Client.1.1.2-preview0008\Microsoft.Identity.Client.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\CxCache\Microsoft.IdentityModel.Clients.ActiveDirectory.2.14.201151115\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.14.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\CxCache\Microsoft.IdentityModel.Clients.ActiveDirectory.2.14.201151115\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Identity.Client, Version=1.1.4.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.1.1.4-preview0002\lib\net45\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\AsyncUsageAnalyzers.1.0.0-alpha003\analyzers\dotnet\AsyncUsageAnalyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Client/MsalAuthHelper.cs
+++ b/Client/MsalAuthHelper.cs
@@ -21,11 +21,10 @@
 
 namespace DeltaQueryClient
 {
+    using Microsoft.Identity.Client;
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Microsoft.Identity.Client;
-    using System.Windows.Forms;
     using System.Windows.Forms;
 
     class MsalAuthHelper

--- a/Client/packages.config
+++ b/Client/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.14.201151115" targetFramework="net45" />
+  <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net45" developmentDependency="true" />
+  <package id="Microsoft.Identity.Client" version="1.1.4-preview0002" targetFramework="net45" />
 </packages>

--- a/ConsoleApplication/DeltaQueryConsoleApplication.csproj
+++ b/ConsoleApplication/DeltaQueryConsoleApplication.csproj
@@ -78,13 +78,8 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Identity.Client, Version=1.1.2.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\CxCache\Microsoft.Identity.Client.1.1.2-preview0008\lib\net45\Microsoft.Identity.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/ConsoleApplication/app.config
+++ b/ConsoleApplication/app.config
@@ -4,7 +4,7 @@
      <!--Windows Azure AD tenant domain name--> 
     <add key="TenantDomainName" value="To be filled in"/>
      <!--Service principal credentials-->  
-    <add key="AppPrincipalId" value="To be filled in"/>
+    <add key="AppPrincipalId" value="edd4904c-ac06-4f13-b8b5-9ec799e82bd3"/>
     <add key="AppVersion" value=""/>
     <!-- Polling interval in seconds -->
     <add key="PullIntervalSec" value="60"/>

--- a/ConsoleApplication/packages.config
+++ b/ConsoleApplication/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.Identity.Client" version="1.1.2-preview0008" targetFramework="net45" />
-</packages>

--- a/DeltaQuerySample.sln
+++ b/DeltaQuerySample.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2003
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeltaQueryConsoleApplication", "ConsoleApplication\DeltaQueryConsoleApplication.csproj", "{FE14AE0B-4328-4633-ABFA-C87000175BD2}"
 EndProject
@@ -34,5 +34,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {19CAD7FA-EBFB-47E7-94ED-ECEE3661264B}
 	EndGlobalSection
 EndGlobal

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <packageRestore>
+    <add key="enabled" value="True" />
+    <add key="automatic" value="True" />
+  </packageRestore>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <config>
+    <add key="repositoryPath" value=".\packages" />
+  </config>
+</configuration>


### PR DESCRIPTION
Build was failing due to VS's hard-coded reference paths in csproj files. The project was set to use `..\..\..\..\CxCache\` for NuGet packages, but not all dev boxes are configured with this kind of path. Added NuGet.config to force a local `packages` directory and load references from there.

Also cleaned out unused packages from packages.config and updates to latest MSAL.

Fixes #6
Fixes #14